### PR TITLE
Improvements

### DIFF
--- a/src/frcurrentsUIDialog.cpp
+++ b/src/frcurrentsUIDialog.cpp
@@ -463,25 +463,11 @@ void frcurrentsUIDialog::OnNow(wxCommandEvent& event) {
 
   m_myChoice = m_choice2->GetSelection();
 
-  switch (button_id) {  // And make the label depending HW+6, HW-6 etc
-    case 0: {
-      next_id = 0;
-      back_id = 12;
-      m_myChoice--;
-      break;
-    }
-    case 12: {
-      next_id = 12;
-      back_id = 11;
-      // m_myChoice++;
-      break;
-    }
+  next_id = button_id;
 
-    default: {
-      next_id = button_id + 1;
-      back_id = button_id - 1;
-    }
-  }
+  m_bNext = false;
+  m_bPrev = false;
+  m_bChooseTide = true;
 
   RequestRefresh(pParent);
 }
@@ -518,25 +504,11 @@ void frcurrentsUIDialog::SetNow() {
 
   m_myChoice = m_choice2->GetSelection();
 
-  switch (button_id) {  // And make the label depending HW+6, HW-6 etc
-    case 0: {
-      next_id = 1;
-      back_id = 12;
-      m_myChoice--;
-      break;
-    }
-    case 12: {
-      next_id = 0;
-      back_id = 11;
-      m_myChoice++;
-      break;
-    }
+  next_id = button_id;
 
-    default: {
-      next_id = button_id + 1;
-      back_id = button_id - 1;
-    }
-  }
+  m_bNext = false;
+  m_bPrev = false;
+  m_bChooseTide = true;
 
   RequestRefresh(pParent);
 }
@@ -2423,7 +2395,6 @@ void frcurrentsUIDialog::OnPrev(wxCommandEvent& event) {
 
       if (myDateSelection > 0) {
         m_myChoice--;
-        m_choice2->SetSelection(m_myChoice);
       }
 
       if (myDateSelection == 0) {
@@ -2473,7 +2444,7 @@ void frcurrentsUIDialog::OnNext(wxCommandEvent& event) {
     m_bChooseTide = false;
   }
   int c = m_choice2->GetCount();
-  m_myChoice = m_choice2->GetSelection();
+  m_choice2->SetSelection(m_myChoice);
 
   // CreateFileArray();
   if (m_bPrev) {
@@ -2556,7 +2527,6 @@ void frcurrentsUIDialog::OnNext(wxCommandEvent& event) {
 
       if (myDateSelection < c - 1) {
         m_myChoice++;
-        m_choice2->SetSelection(m_myChoice);
       }
 
       break;

--- a/src/frcurrentsUIDialog.cpp
+++ b/src/frcurrentsUIDialog.cpp
@@ -447,9 +447,9 @@ void frcurrentsUIDialog::OnNow(wxCommandEvent& event) {
     button_id = 0;
   }
   if (m_bUseBM) {
-    m_staticText2->SetLabel(label_lw[button_id]);
+    m_staticText211->SetLabel(label_lw[button_id]);
   } else {
-    m_staticText2->SetLabel(label_array[button_id]);
+    m_staticText211->SetLabel(label_array[button_id]);
   }
 
   wxDateTime this_now = wxDateTime::Now();
@@ -457,7 +457,7 @@ void frcurrentsUIDialog::OnNow(wxCommandEvent& event) {
   wxString s1 = this_now.Format("%H:%M");
   wxString s2 = s0 + " " + s1;
 
-  m_staticText211->SetLabel(s2);
+  m_staticText2->SetLabel(s2);
 
   SetCorrectHWSelection();
 
@@ -502,9 +502,9 @@ void frcurrentsUIDialog::SetNow() {
   }
 
   if (m_bUseBM) {
-    m_staticText2->SetLabel(label_lw[button_id]);
+    m_staticText211->SetLabel(label_lw[button_id]);
   } else {
-    m_staticText2->SetLabel(label_array[button_id]);
+    m_staticText211->SetLabel(label_array[button_id]);
   }
 
   wxDateTime this_now = wxDateTime::Now();
@@ -512,7 +512,7 @@ void frcurrentsUIDialog::SetNow() {
   wxString s1 = this_now.Format("%H:%M");
   wxString s2 = s0 + " " + s1;
 
-  m_staticText211->SetLabel(s2);
+  m_staticText2->SetLabel(s2);
 
   SetCorrectHWSelection();
 
@@ -1972,8 +1972,6 @@ void frcurrentsUIDialog::GetCurrents(wxString dirname, wxString filename) {
   wxString tidePort = token[0];
 
   m_bUseBM = false;
-  m_button5->SetLabel(_("HW"));
-  m_staticTextHW->SetLabel(_("Select High Water"));
 
   if (tidePort == "ILE de GROIX (Port Tudy)") {
     tidePort = "PORT-TUDY";
@@ -1982,14 +1980,22 @@ void frcurrentsUIDialog::GetCurrents(wxString dirname, wxString filename) {
   } else if (tidePort == "LE HAVRE") {
     tidePort = "LE HAVRE.BM";
     m_bUseBM = true;
-    m_button5->SetLabel(_("LW"));
-    m_staticTextHW->SetLabel(_("Select Low Water"));
   } else if (tidePort == "LA ROCHELLE - LA PALLICE") {
     tidePort = "LA_ROCHELLE_BM";
     m_bUseBM = true;
+  }
+  if (m_bUseBM) {
     m_button5->SetLabel(_("LW"));
     m_staticTextHW->SetLabel(_("Select Low Water"));
+    m_button4->SetLabel(_("LW -6"));
+    m_button6->SetLabel(_("LW +6"));
+  } else {
+    m_button5->SetLabel(_("HW"));
+    m_staticTextHW->SetLabel(_("Select High Water"));
+    m_button4->SetLabel(_("HW -6"));
+    m_button6->SetLabel(_("HW +6"));
   }
+
 
   wxString filePort;
   // wxMessageBox(tidePort);
@@ -2281,7 +2287,9 @@ void frcurrentsUIDialog::OnChooseTideButton(wxCommandEvent& event) {
     case 6: {
       next_id = 6;
       m_myChoice = m_choice2->GetSelection();
-      m_staticText2->SetLabel(st_mydate);
+      m_dt.Add(m_ts);
+      wxString s = m_dt.Format("%a %d %b %Y %H:%M");
+      m_staticText2->SetLabel(s);
       break;
     }
     case 0: {

--- a/src/frcurrentsUIDialog.cpp
+++ b/src/frcurrentsUIDialog.cpp
@@ -2334,9 +2334,11 @@ void frcurrentsUIDialog::OnPrev(wxCommandEvent& event) {
   int c, p;
 
   m_bPrev = true;
+  bool again = false;
 
   if (m_bChooseTide) {
     //wxMessageBox("Please click Previous again");
+    again = true;
     m_bChooseTide = false;
   }
   c = m_choice2->GetCount();
@@ -2355,6 +2357,7 @@ void frcurrentsUIDialog::OnPrev(wxCommandEvent& event) {
       }
     }
     //wxMessageBox("Please click Previous again");
+    again = true;
     m_bNext = false;
   }
 
@@ -2451,8 +2454,10 @@ void frcurrentsUIDialog::OnPrev(wxCommandEvent& event) {
   } else {
     m_staticText211->SetLabel(label_array[button_id]);
   }
-
-  RequestRefresh(pParent);
+  if (again)
+    OnPrev(event);
+  else
+    RequestRefresh(pParent);
 }
 
 void frcurrentsUIDialog::OnNext(wxCommandEvent& event) {
@@ -2460,9 +2465,11 @@ void frcurrentsUIDialog::OnNext(wxCommandEvent& event) {
 
   wxString s;
   wxString st_mydate;
+  bool again = false;
 
   if (m_bChooseTide) {
     //wxMessageBox("Please click Next again");
+    again = true;
     m_bChooseTide = false;
   }
   int c = m_choice2->GetCount();
@@ -2483,6 +2490,7 @@ void frcurrentsUIDialog::OnNext(wxCommandEvent& event) {
       }
     }
     //wxMessageBox("Please click Next again");
+    again = true;
     m_bPrev = false;
   }
 
@@ -2590,8 +2598,10 @@ void frcurrentsUIDialog::OnNext(wxCommandEvent& event) {
   } else {
     m_staticText211->SetLabel(label_array[button_id]);
   }
-
-  RequestRefresh(pParent);
+  if (again)
+    OnNext(event);
+  else
+    RequestRefresh(pParent);
 }
 
 void frcurrentsUIDialog::About(wxCommandEvent& event) {

--- a/src/frcurrentsUIDialog.cpp
+++ b/src/frcurrentsUIDialog.cpp
@@ -586,7 +586,7 @@ void frcurrentsUIDialog::OnDateSelChanged(wxDateEvent& event) {
     wxMessageBox(_("No tidal data"));
     return;
   }
-  if (s == "LE HAVRE, France" || s == "LA ROCHELLE - LA PALLICE, France") {
+  if(m_bUseBM){
     CalcLW(i);
   } else {
     CalcHW(i);
@@ -598,6 +598,19 @@ void frcurrentsUIDialog::OnDateSelChanged(wxDateEvent& event) {
   m_textCtrlCoefficient->SetValue("Coeff: " + s_coeff);
   GetCurrentsData(s);
   SetCorrectHWSelection();
+
+  if (m_bUseBM) {
+    m_staticText211->SetLabel(label_lw[button_id]);
+  }
+  else {
+    m_staticText211->SetLabel(label_array[button_id]);
+  }
+
+  m_myChoice = m_choice2->GetSelection();
+  m_dt.ParseDateTime(m_choice2->GetString(m_myChoice));
+  m_dt.Subtract(wxTimeSpan::Hours(6));
+  m_dt.Add(wxTimeSpan::Hours(button_id));
+  m_staticText2->SetLabel(m_dt.Format("%a %d %b %Y %H:%M"));
 
   RequestRefresh(pParent);
 }


### PR DESCRIPTION
Hi, I propose you two small commits
1)
there were some "jumps" in the hours and gap to or from HW or LW when clicking on Prev or Next button after clicking on Now button (OnNow function)  or selecting another Port (SetNow function)
2)
When selecting a new date, the tide overlay is updated, but the date & time and the gap to or from the HW or LW were not displayed.
J.P.

