### PR TITLE
Improve behavior

### DIFF
--- a/src/frcurrentsUIDialog.cpp
+++ b/src/frcurrentsUIDialog.cpp
@@ -463,25 +463,11 @@ void frcurrentsUIDialog::OnNow(wxCommandEvent& event) {
 
   m_myChoice = m_choice2->GetSelection();
 
-  switch (button_id) {  // And make the label depending HW+6, HW-6 etc
-    case 0: {
-      next_id = 0;
-      back_id = 12;
-      m_myChoice--;
-      break;
-    }
-    case 12: {
-      next_id = 12;
-      back_id = 11;
-      // m_myChoice++;
-      break;
-    }
+  next_id = button_id;
 
-    default: {
-      next_id = button_id + 1;
-      back_id = button_id - 1;
-    }
-  }
+  m_bNext = false;
+  m_bPrev = false;
+  m_bChooseTide = true;
 
   RequestRefresh(pParent);
 }
@@ -518,25 +504,11 @@ void frcurrentsUIDialog::SetNow() {
 
   m_myChoice = m_choice2->GetSelection();
 
-  switch (button_id) {  // And make the label depending HW+6, HW-6 etc
-    case 0: {
-      next_id = 1;
-      back_id = 12;
-      m_myChoice--;
-      break;
-    }
-    case 12: {
-      next_id = 0;
-      back_id = 11;
-      m_myChoice++;
-      break;
-    }
+  next_id = button_id;
 
-    default: {
-      next_id = button_id + 1;
-      back_id = button_id - 1;
-    }
-  }
+  m_bNext = false;
+  m_bPrev = false;
+  m_bChooseTide = true;
 
   RequestRefresh(pParent);
 }
@@ -2423,7 +2395,6 @@ void frcurrentsUIDialog::OnPrev(wxCommandEvent& event) {
 
       if (myDateSelection > 0) {
         m_myChoice--;
-        m_choice2->SetSelection(m_myChoice);
       }
 
       if (myDateSelection == 0) {
@@ -2473,7 +2444,7 @@ void frcurrentsUIDialog::OnNext(wxCommandEvent& event) {
     m_bChooseTide = false;
   }
   int c = m_choice2->GetCount();
-  m_myChoice = m_choice2->GetSelection();
+  m_choice2->SetSelection(m_myChoice);
 
   // CreateFileArray();
   if (m_bPrev) {
@@ -2556,7 +2527,6 @@ void frcurrentsUIDialog::OnNext(wxCommandEvent& event) {
 
       if (myDateSelection < c - 1) {
         m_myChoice++;
-        m_choice2->SetSelection(m_myChoice);
       }
 
       break;

--- a/src/frcurrentsUIDialog.cpp
+++ b/src/frcurrentsUIDialog.cpp
@@ -447,9 +447,9 @@ void frcurrentsUIDialog::OnNow(wxCommandEvent& event) {
     button_id = 0;
   }
   if (m_bUseBM) {
-    m_staticText2->SetLabel(label_lw[button_id]);
+    m_staticText211->SetLabel(label_lw[button_id]);
   } else {
-    m_staticText2->SetLabel(label_array[button_id]);
+    m_staticText211->SetLabel(label_array[button_id]);
   }
 
   wxDateTime this_now = wxDateTime::Now();
@@ -457,7 +457,7 @@ void frcurrentsUIDialog::OnNow(wxCommandEvent& event) {
   wxString s1 = this_now.Format("%H:%M");
   wxString s2 = s0 + " " + s1;
 
-  m_staticText211->SetLabel(s2);
+  m_staticText2->SetLabel(s2);
 
   SetCorrectHWSelection();
 
@@ -502,9 +502,9 @@ void frcurrentsUIDialog::SetNow() {
   }
 
   if (m_bUseBM) {
-    m_staticText2->SetLabel(label_lw[button_id]);
+    m_staticText211->SetLabel(label_lw[button_id]);
   } else {
-    m_staticText2->SetLabel(label_array[button_id]);
+    m_staticText211->SetLabel(label_array[button_id]);
   }
 
   wxDateTime this_now = wxDateTime::Now();
@@ -512,7 +512,7 @@ void frcurrentsUIDialog::SetNow() {
   wxString s1 = this_now.Format("%H:%M");
   wxString s2 = s0 + " " + s1;
 
-  m_staticText211->SetLabel(s2);
+  m_staticText2->SetLabel(s2);
 
   SetCorrectHWSelection();
 
@@ -1972,8 +1972,6 @@ void frcurrentsUIDialog::GetCurrents(wxString dirname, wxString filename) {
   wxString tidePort = token[0];
 
   m_bUseBM = false;
-  m_button5->SetLabel(_("HW"));
-  m_staticTextHW->SetLabel(_("Select High Water"));
 
   if (tidePort == "ILE de GROIX (Port Tudy)") {
     tidePort = "PORT-TUDY";
@@ -1982,14 +1980,22 @@ void frcurrentsUIDialog::GetCurrents(wxString dirname, wxString filename) {
   } else if (tidePort == "LE HAVRE") {
     tidePort = "LE HAVRE.BM";
     m_bUseBM = true;
-    m_button5->SetLabel(_("LW"));
-    m_staticTextHW->SetLabel(_("Select Low Water"));
   } else if (tidePort == "LA ROCHELLE - LA PALLICE") {
     tidePort = "LA_ROCHELLE_BM";
     m_bUseBM = true;
+  }
+  if (m_bUseBM) {
     m_button5->SetLabel(_("LW"));
     m_staticTextHW->SetLabel(_("Select Low Water"));
+    m_button4->SetLabel(_("LW -6"));
+    m_button6->SetLabel(_("LW +6"));
+  } else {
+    m_button5->SetLabel(_("HW"));
+    m_staticTextHW->SetLabel(_("Select High Water"));
+    m_button4->SetLabel(_("HW -6"));
+    m_button6->SetLabel(_("HW +6"));
   }
+
 
   wxString filePort;
   // wxMessageBox(tidePort);
@@ -2281,7 +2287,9 @@ void frcurrentsUIDialog::OnChooseTideButton(wxCommandEvent& event) {
     case 6: {
       next_id = 6;
       m_myChoice = m_choice2->GetSelection();
-      m_staticText2->SetLabel(st_mydate);
+      m_dt.Add(m_ts);
+      wxString s = m_dt.Format("%a %d %b %Y %H:%M");
+      m_staticText2->SetLabel(s);
       break;
     }
     case 0: {

--- a/src/frcurrentsUIDialog.cpp
+++ b/src/frcurrentsUIDialog.cpp
@@ -1192,14 +1192,13 @@ double frcurrentsUIDialog::CalcRange_Brest() {
   myHeightLW = 0;
 
   // The tide/current modules calculate values based on PC local time
-  // We want UTC, so adjust accordingly
+  // We need  LMT at station, so adjust accordingly
   int tt_localtz = m_t_graphday_GMT + (m_diff_mins * 60);
+  tt_localtz -= m_stationOffset_mins * 60;  // LMT at station
 
   // get tide flow sens ( flood or ebb ? )
   ptcmgr->GetTideFlowSens(tt_localtz, BACKWARD_TEN_MINUTES_STEP,
                           pIDX->IDX_rec_num, tcv[0], val, wt);
-  // if (m_tzoneDisplay == 0)
-  tt_localtz -= m_stationOffset_mins * 60;  // LMT at station
 
   for (i = 0; i < 26; i++) {
     int tt = tt_localtz + (i * FORWARD_ONE_HOUR_STEP);
@@ -1303,14 +1302,13 @@ void frcurrentsUIDialog::CalcHW(int PortCode) {
   myHeightLW = 0;
 
   // The tide/current modules calculate values based on PC local time
-  // We want UTC, so adjust accordingly
+  // We need  LMT at station, so adjust accordingly
   int tt_localtz = m_t_graphday_GMT + (m_diff_mins * 60);
+  tt_localtz -= m_stationOffset_mins * 60;  // LMT at station
 
   // get tide flow sens ( flood or ebb ? )
   ptcmgr->GetTideFlowSens(tt_localtz, BACKWARD_TEN_MINUTES_STEP,
                           pIDX->IDX_rec_num, tcv[0], val, wt);
-  // if (m_tzoneDisplay == 0)
-  tt_localtz -= m_stationOffset_mins * 60;  // LMT at station
 
   for (i = 0; i < 26; i++) {
     int tt = tt_localtz + (i * FORWARD_ONE_HOUR_STEP);
@@ -1423,14 +1421,14 @@ void frcurrentsUIDialog::CalcLW(int PortCode) {
   myHeightLW = 0;
 
   // The tide/current modules calculate values based on PC local time
-  // We want UTC, so adjust accordingly
+  // We need  LMT at station, so adjust accordingly
   int tt_localtz = m_t_graphday_GMT + (m_diff_mins * 60);
+  tt_localtz -= m_stationOffset_mins * 60;  //LMT at station
 
   // get tide flow sens ( flood or ebb ? )
   ptcmgr->GetTideFlowSens(tt_localtz, BACKWARD_TEN_MINUTES_STEP,
                           pIDX->IDX_rec_num, tcv[0], val, wt);
-  // if (m_tzoneDisplay == 0)
-  tt_localtz -= m_stationOffset_mins * 60;  // LMT at station
+
 
   for (i = 0; i < 26; i++) {
     int tt = tt_localtz + (i * FORWARD_ONE_HOUR_STEP);

--- a/src/frcurrentsUIDialog.cpp
+++ b/src/frcurrentsUIDialog.cpp
@@ -2334,9 +2334,11 @@ void frcurrentsUIDialog::OnPrev(wxCommandEvent& event) {
   int c, p;
 
   m_bPrev = true;
+  bool again = false;
 
   if (m_bChooseTide) {
     //wxMessageBox("Please click Previous again");
+    again = true;
     m_bChooseTide = false;
   }
   c = m_choice2->GetCount();
@@ -2355,6 +2357,7 @@ void frcurrentsUIDialog::OnPrev(wxCommandEvent& event) {
       }
     }
     //wxMessageBox("Please click Previous again");
+    again = true;
     m_bNext = false;
   }
 
@@ -2451,8 +2454,10 @@ void frcurrentsUIDialog::OnPrev(wxCommandEvent& event) {
   } else {
     m_staticText211->SetLabel(label_array[button_id]);
   }
-
-  RequestRefresh(pParent);
+  if (again)
+    OnPrev(event);
+  else
+    RequestRefresh(pParent);
 }
 
 void frcurrentsUIDialog::OnNext(wxCommandEvent& event) {
@@ -2460,9 +2465,11 @@ void frcurrentsUIDialog::OnNext(wxCommandEvent& event) {
 
   wxString s;
   wxString st_mydate;
+  bool again = false;
 
   if (m_bChooseTide) {
     //wxMessageBox("Please click Next again");
+    again = true;
     m_bChooseTide = false;
   }
   int c = m_choice2->GetCount();
@@ -2483,6 +2490,7 @@ void frcurrentsUIDialog::OnNext(wxCommandEvent& event) {
       }
     }
     //wxMessageBox("Please click Next again");
+    again = true;
     m_bPrev = false;
   }
 
@@ -2590,8 +2598,10 @@ void frcurrentsUIDialog::OnNext(wxCommandEvent& event) {
   } else {
     m_staticText211->SetLabel(label_array[button_id]);
   }
-
-  RequestRefresh(pParent);
+  if (again)
+    OnNext(event);
+  else
+    RequestRefresh(pParent);
 }
 
 void frcurrentsUIDialog::About(wxCommandEvent& event) {

--- a/src/frcurrentsUIDialog.cpp
+++ b/src/frcurrentsUIDialog.cpp
@@ -174,6 +174,7 @@ frcurrentsUIDialog::frcurrentsUIDialog(wxWindow* parent, frcurrents_pi* ppi)
 
     pConf->Read("frcurrentsUseArrowStyle", &m_UseArrowStyle);
 
+    pConf->Read("frcurrentsArea", &m_AreaSelected);
     pConf->Read("frcurrentsPort", &m_PortSelected);
     pConf->Read("frcurrentsFolder", &m_FolderSelected);
 
@@ -208,7 +209,6 @@ frcurrentsUIDialog::frcurrentsUIDialog(wxWindow* parent, frcurrents_pi* ppi)
   LoadStandardPorts();  // From StandardPorts.xml Load the port choice control
   LoadTCMFile();
   LoadHarmonics();
-  m_choice1->SetStringSelection(m_PortSelected);  // from opencpn.ini
 
   OpenFile();        // Set up variables
   OnStartSetupHW();  // Set up the HW control and information text controls
@@ -234,6 +234,9 @@ frcurrentsUIDialog::~frcurrentsUIDialog() {
     pConf->Write("VColour3", myVColour[3]);
     pConf->Write("VColour4", myVColour[4]);
 
+    int b = m_choiceArea->GetCurrentSelection();
+    wxString myA = m_choiceArea->GetString(b);
+    pConf->Write("frcurrentsArea", myA);
     int c = m_choice1->GetCurrentSelection();
     wxString myP = m_choice1->GetString(c);
     pConf->Write("frcurrentsPort", myP);
@@ -422,12 +425,19 @@ void frcurrentsUIDialog::OpenFile(bool newestFile) {
 
 void frcurrentsUIDialog::OnStartSetupHW() {
   m_bOnStart = true;
-  int a = 0;
-  int an = 0;
-  a = m_choiceArea->GetSelection();
-  wxString s = m_choiceArea->GetString(a);
+  //find area ID and select it
+  int id;
+  id = m_choiceArea->FindString(m_AreaSelected, true);
+  if (id == wxNOT_FOUND) id = 0;
+  m_choiceArea->SetSelection(id);
+  wxString s = m_choiceArea->GetString(id);
 
   FindTidePortUsingChoice(s);
+
+  //find port ID and select it
+  id = m_choice1->FindString(m_PortSelected, true);
+  if (id == wxNOT_FOUND) id = 0;
+  m_choice1->SetSelection(id);
 
   OnPortListed();
 }
@@ -906,8 +916,6 @@ int frcurrentsUIDialog::FindTidePortUsingChoice(wxString inAreaNumber) {
     }
     i++;
   }
-  m_choice1->SetSelection(0);
-  RequestRefresh(pParent);
   return 0;
 }
 
@@ -1905,10 +1913,10 @@ void frcurrentsUIDialog::OnAreaSelected(wxCommandEvent& event) {
   wxString s = m_choiceArea->GetString(a);
 
   FindTidePortUsingChoice(s);
+  m_choice1->SetSelection(0);
 
   OnPortListed();
 
-  SetNow();
 }
 
 void frcurrentsUIDialog::GetCurrentsData(wxString areaFolder) {

--- a/src/frcurrentsUIDialog.cpp
+++ b/src/frcurrentsUIDialog.cpp
@@ -780,7 +780,7 @@ void frcurrentsUIDialog::SetDateForNowButton() {
         BrestRange = CalcRange_Brest();
         m_coeff = CalcCoefficient();
         wxString s_coeff = wxString::Format("%3.0f", m_coeff);
-        m_textCtrlCoefficient->SetValue(s_coeff);
+        m_textCtrlCoefficient->SetValue("Coeff: " + s_coeff);
 
         GetCurrentsData(sa);
         m_choice2->SetSelection(0);
@@ -802,7 +802,7 @@ void frcurrentsUIDialog::SetDateForNowButton() {
         BrestRange = CalcRange_Brest();
         m_coeff = CalcCoefficient();
         wxString s_coeff = wxString::Format("%3.0f", m_coeff);
-        m_textCtrlCoefficient->SetValue(s_coeff);
+        m_textCtrlCoefficient->SetValue("Coeff: " + s_coeff);
 
         GetCurrentsData(sa);
         c = m_choice2->GetCount();

--- a/src/frcurrentsUIDialog.cpp
+++ b/src/frcurrentsUIDialog.cpp
@@ -586,7 +586,7 @@ void frcurrentsUIDialog::OnDateSelChanged(wxDateEvent& event) {
     wxMessageBox(_("No tidal data"));
     return;
   }
-  if (s == "LE HAVRE, France" || s == "LA ROCHELLE - LA PALLICE, France") {
+  if(m_bUseBM){
     CalcLW(i);
   } else {
     CalcHW(i);
@@ -598,6 +598,19 @@ void frcurrentsUIDialog::OnDateSelChanged(wxDateEvent& event) {
   m_textCtrlCoefficient->SetValue("Coeff: " + s_coeff);
   GetCurrentsData(s);
   SetCorrectHWSelection();
+
+  if (m_bUseBM) {
+    m_staticText211->SetLabel(label_lw[button_id]);
+  }
+  else {
+    m_staticText211->SetLabel(label_array[button_id]);
+  }
+
+  m_myChoice = m_choice2->GetSelection();
+  m_dt.ParseDateTime(m_choice2->GetString(m_myChoice));
+  m_dt.Subtract(wxTimeSpan::Hours(6));
+  m_dt.Add(wxTimeSpan::Hours(button_id));
+  m_staticText2->SetLabel(m_dt.Format("%a %d %b %Y %H:%M"));
 
   RequestRefresh(pParent);
 }

--- a/src/frcurrentsUIDialog.h
+++ b/src/frcurrentsUIDialog.h
@@ -183,6 +183,7 @@ public:
   int round(double c);
 
   wxString m_PortSelected;
+  wxString m_AreaSelected;
   wxArrayString TideCurrentDataSet;
   wxString* pTC_Dir;
   vector<SHOMport> portLines;

--- a/src/frcurrentsUIDialog.h
+++ b/src/frcurrentsUIDialog.h
@@ -284,7 +284,7 @@ private:
   float tcv[26];
 
   int myDateSelection;
-  int myNewDateSelection;
+  wxDateTime m_SelectedDate; //  to store the current selected date
   wxString euTC[8][4];  // Date.Time, Height, Units, HW.LW
   wxDateTime m_dt;
   wxDateTime choice_dt;


### PR DESCRIPTION
I propose here to improve behaviour of DatePickerCtrl
Currently, The different date elements are independents. When you scroll up days and arrive to the month's end, you loop to the start of the same month. The same when scrolling months, and the same in the down sense.
I propose to change that and changing month and year accordingly with the change of days/months.
I also introduce a range to prevent crashes when the date reaches the limit of the time_t storage capacity. (it's very easy if the user scrolls years and "forget" his finger on the keyboard...)  May be it will be a solution to ovoid Ticks and time_t ?
JP