### PR TITLE
Correct LW / HW calculation (again)

### DIFF
--- a/src/frcurrentsUIDialog.cpp
+++ b/src/frcurrentsUIDialog.cpp
@@ -1385,6 +1385,9 @@ void frcurrentsUIDialog::CalcHW(int PortCode) {
   int tt_localtz = m_t_graphday_GMT + (m_diff_mins * 60);
   tt_localtz -= m_stationOffset_mins * 60;  // LMT at station
 
+  //  Get the day after
+  int tt_nextlocaltzday = tt_localtz + (24 * 3600);
+
   // get tide flow sens ( flood or ebb ? )
   ptcmgr->GetTideFlowSens(tt_localtz, BACKWARD_TEN_MINUTES_STEP,
                           pIDX->IDX_rec_num, tcv[0], val, wt);
@@ -1405,7 +1408,7 @@ void frcurrentsUIDialog::CalcHW(int PortCode) {
         ptcmgr->GetHightOrLowTide(tt, BACKWARD_TEN_MINUTES_STEP,
                                   BACKWARD_ONE_MINUTES_STEP, tcv[i], wt,
                                   pIDX->IDX_rec_num, tcvalue, tctime);
-        if (tctime > tt_localtz) {  // Only show events visible in graphic
+        if (tctime > tt_localtz && tctime < tt_nextlocaltzday) {  // Only show events visible in graphic
           // presently shown
           wxDateTime tcd;  // write date
           wxString s, s1, s2;
@@ -1504,6 +1507,9 @@ void frcurrentsUIDialog::CalcLW(int PortCode) {
   int tt_localtz = m_t_graphday_GMT + (m_diff_mins * 60);
   tt_localtz -= m_stationOffset_mins * 60;  //  LMT at station
 
+  //  Get the day after
+  int tt_nextlocaltzday = tt_localtz + (24 * 3600);
+
   // get tide flow sens ( flood or ebb ? )
   ptcmgr->GetTideFlowSens(tt_localtz, BACKWARD_TEN_MINUTES_STEP,
                           pIDX->IDX_rec_num, tcv[0], val, wt);
@@ -1525,7 +1531,7 @@ void frcurrentsUIDialog::CalcLW(int PortCode) {
         ptcmgr->GetHightOrLowTide(tt, BACKWARD_TEN_MINUTES_STEP,
                                   BACKWARD_ONE_MINUTES_STEP, tcv[i], wt,
                                   pIDX->IDX_rec_num, tcvalue, tctime);
-        if (tctime > tt_localtz) {  // Only show events
+        if (tctime > tt_localtz && tctime < tt_nextlocaltzday) {  // Only show events
                                     // visible in graphic
           // presently shown
           wxDateTime tcd;  // write date


### PR DESCRIPTION
I completely rebuilt my environment with a new clone. Hope that will do it now.
This commit correct a dysfunction when the HW (LW for some stations)  is just after noon in the next day.
In this case, it is listed both in the current and the next day. This disrupts using next and prev buttons. Examples on the 8th and 23rd of January 2025.
The same behaviour on the Open CPN core.
