### PR TITLE
Correct date change when now and nearear HW time are not in the same day

### DIFF
--- a/src/frcurrentsUIDialog.cpp
+++ b/src/frcurrentsUIDialog.cpp
@@ -667,9 +667,6 @@ void frcurrentsUIDialog::OnDateSelChanged(wxDateEvent& event) {
   m_textCtrlCoefficient->SetValue("Coeff: " + s_coeff);
   GetCurrentsData(s);
 
-  if (m_SelectedDate.IsSameDate(wxDateTime::Now()))
-    SetNow();
-  else {
     button_id = 6;     //  in another days as today, set to HW/LW
 
     if (later)
@@ -698,7 +695,6 @@ void frcurrentsUIDialog::OnDateSelChanged(wxDateEvent& event) {
     m_bChooseTide = true;
 
     RequestRefresh(pParent);
-  }
 }
 
 void frcurrentsUIDialog::OnPortChanged(wxCommandEvent& event) {


### PR DESCRIPTION
When the date is changed through the date picker, it is impossible to go back to now time when the now time is very near the beginning or the end of the day and the nearer tide time is in the day after or before. The datepicker is blocked...
JP