### PR TITLE
Sorting Areas and Ports

### DIFF
--- a/data/StandardPorts.xml
+++ b/data/StandardPorts.xml
@@ -1,4 +1,15 @@
 ﻿<DocumentElement>
+	<Table1>
+    <PORT_NUMBER>557</PORT_NUMBER>
+    <PORT_NAME>DUNKERQUE, France</PORT_NAME>
+    <LAT>51.039995</LAT>
+    <LON>2.346700</LON>
+    <PMVE>6.05</PMVE>
+    <PMME>5.0</PMME>
+    <BMME>1.5</BMME>
+    <BMVE>0.6</BMVE>
+    <IDX>DUNKERQUE, France</IDX>
+  </Table1>
    <Table1>
   <PORT_NUMBER>557</PORT_NUMBER>
     <PORT_NAME>CALAIS, France</PORT_NAME>
@@ -9,17 +20,6 @@
     <BMME>2.05</BMME>
     <BMVE>0.8</BMVE>
     <IDX>CALAIS, France</IDX>
-  </Table1>
-      <Table1>
-    <PORT_NUMBER>557</PORT_NUMBER>
-    <PORT_NAME>DUNKERQUE, France</PORT_NAME>
-    <LAT>51.039995</LAT>
-    <LON>2.346700</LON>
-    <PMVE>6.05</PMVE>
-    <PMME>5.0</PMME>
-    <BMME>1.5</BMME>
-    <BMVE>0.6</BMVE>
-    <IDX>DUNKERQUE, France</IDX>
   </Table1>
     <Table1>
     <PORT_NUMBER>557</PORT_NUMBER>
@@ -65,6 +65,17 @@
     <BMVE>0.7</BMVE>
     <IDX>PORT-NAVALO, France</IDX>
   </Table1>
+		<Table1>
+    <PORT_NUMBER>559</PORT_NUMBER>
+    <PORT_NAME>SAINT-NAZAIRE, France</PORT_NAME>
+    <LAT>47.277400</LAT>
+    <LON>-2.21700</LON>
+    <PMVE>5.90</PMVE>
+    <PMME>4.70</PMME>
+    <BMME>2.25</BMME>
+    <BMVE>0.85</BMVE>
+    <IDX>SAINT-NAZAIRE, France</IDX>
+  </Table1>
       <Table1>
     <PORT_NUMBER>559</PORT_NUMBER>
     <PORT_NAME>LES SABLES-D'OLONNE, France</PORT_NAME>
@@ -86,17 +97,6 @@
     <BMME>2.50</BMME>
     <BMVE>1.0</BMVE>
     <IDX>LA ROCHELLE - LA PALLICE, France</IDX>
-  </Table1>
-         <Table1>
-    <PORT_NUMBER>559</PORT_NUMBER>
-    <PORT_NAME>SAINT-NAZAIRE, France</PORT_NAME>
-    <LAT>47.277400</LAT>
-    <LON>-2.21700</LON>
-    <PMVE>5.90</PMVE>
-    <PMME>4.70</PMME>
-    <BMME>2.25</BMME>
-    <BMVE>0.85</BMVE>
-    <IDX>SAINT-NAZAIRE, France</IDX>
   </Table1>
        <Table1>
     <PORT_NUMBER>559</PORT_NUMBER>
@@ -120,6 +120,17 @@
     <BMVE>1.15</BMVE>
     <IDX>BREST, France</IDX>
   </Table1>
+		<Table1>
+    <PORT_NUMBER>561</PORT_NUMBER>
+    <PORT_NAME>LE HAVRE, France</PORT_NAME>
+    <LAT>49.4833</LAT>
+    <LON>0.1167</LON>
+    <PMVE>8.00</PMVE>
+    <PMME>6.70</PMME>
+    <BMME>2.95</BMME>
+    <BMVE>1.25</BMVE>
+    <IDX>LE HAVRE, France</IDX>
+  </Table1>
       <Table1>
     <PORT_NUMBER>561</PORT_NUMBER>
     <PORT_NAME>CHERBOURG, France</PORT_NAME>
@@ -130,17 +141,6 @@
     <BMME>2.60</BMME>
     <BMVE>1.15</BMVE>
     <IDX>CHERBOURG, France</IDX>
-  </Table1>
-      <Table1>
-    <PORT_NUMBER>561</PORT_NUMBER>
-    <PORT_NAME>LE HAVRE, France</PORT_NAME>
-    <LAT>49.4833</LAT>
-    <LON>0.1167</LON>
-    <PMVE>8.00</PMVE>
-    <PMME>6.70</PMME>
-    <BMME>2.95</BMME>
-    <BMVE>1.25</BMVE>
-    <IDX>LE HAVRE, France</IDX>
   </Table1>
     <Table1>
     <PORT_NUMBER>562</PORT_NUMBER>

--- a/src/frcurrentsUIDialog.cpp
+++ b/src/frcurrentsUIDialog.cpp
@@ -104,6 +104,9 @@ enum {
   LAST_MONTH_IN_YEAR = 11   //  to 11
 };
 
+wxString m_Areas[] = { _("557"), _("564"), _("561"),_("562"), _("563"),
+    _("560"), _("558"), _("559"), _("565") };
+
 // Handle to DLL
 using namespace std;
 
@@ -494,7 +497,7 @@ void frcurrentsUIDialog::OnStartSetupHW() {
   id = m_choiceArea->FindString(m_AreaSelected, true);
   if (id == wxNOT_FOUND) id = 0;
   m_choiceArea->SetSelection(id);
-  wxString s = m_choiceArea->GetString(id).Left(3);
+  wxString s = m_Areas[id];
 
   FindTidePortUsingChoice(s);  // populate m_choice1 (this area's ports list)
 
@@ -756,7 +759,7 @@ void frcurrentsUIDialog::SetDateForNowButton() {
   m_SelectedDate = this_now.GetDateOnly();
 
   int ma = m_choiceArea->GetCurrentSelection();
-  wxString sa = m_choiceArea->GetString(ma).Left(3);
+  wxString sa = m_Areas[ma];
 
   int m = m_choice1->GetSelection();
   wxString string = m_choice1->GetString(m);
@@ -1932,7 +1935,7 @@ bool frcurrentsUIDialog::OpenXML() {
 void frcurrentsUIDialog::OnAreaSelected(wxCommandEvent& event) {
 
   int a = m_choiceArea->GetSelection();
-  wxString s = m_choiceArea->GetString(a).Left(3);
+  wxString s = m_Areas[a];
 
   FindTidePortUsingChoice(s);  // populate m_choice1 (this area's ports list)
 
@@ -2284,7 +2287,7 @@ void frcurrentsUIDialog::OnPrev(wxCommandEvent& event) {
   wxString st_mydate;
 
   int ma = m_choiceArea->GetCurrentSelection();
-  wxString sa = m_choiceArea->GetString(ma).Left(3);
+  wxString sa = m_Areas[ma];
 
   int p = m_choice1->GetSelection();  // Get the port selected
   wxString s = m_choice1->GetString(p);
@@ -2354,7 +2357,7 @@ void frcurrentsUIDialog::OnNext(wxCommandEvent& event) {
   wxString st_mydate;
 
   int ma = m_choiceArea->GetCurrentSelection();
-  wxString sa = m_choiceArea->GetString(ma).Left(3);
+  wxString sa = m_Areas[ma];
   int p = m_choice1->GetSelection();  // Get the port selected
   wxString s = m_choice1->GetString(p);
 

--- a/src/frcurrentsUIDialogBase.cpp
+++ b/src/frcurrentsUIDialogBase.cpp
@@ -19,10 +19,11 @@ frcurrentsUIDialogBase::frcurrentsUIDialogBase( wxWindow* parent, wxWindowID id,
 	wxStaticBoxSizer* sbSizer71;
 	sbSizer71 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Tidal Area") ), wxHORIZONTAL );
 
-	wxString m_choiceAreaChoices[] = { _("557 Strait of Dover"), _("558 South Brittany"),
-		_("559 Vendee-Gironde"), _("560 Tip of Britanny"), _("561 Fecamp to Cherbourg"),
-		_("562 La Hague to Hx-de-Breat"), _("563 Hx-de-Breat to Brignogan"), _("564 English Channel"),
-		_("565 Bay of Biscay") };
+	wxString m_choiceAreaChoices[] = { _("Strait of Dover"), _("English Channel"),
+		_("Fecamp to La Hague"), _("La Hague to Hx-de-Brehat"),
+		_("Hx-de-Brehat to Brignogan"), _("Tip of Britanny"),
+		_("South Brittany"), _("Vendee-Gironde"), _("Bay of Biscay") };
+
 	int m_choiceAreaNChoices = sizeof( m_choiceAreaChoices ) / sizeof( wxString );
 	m_choiceArea = new wxChoice( sbSizer71->GetStaticBox(), wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choiceAreaNChoices, m_choiceAreaChoices, 0 );
 	m_choiceArea->SetSelection( 0 );


### PR DESCRIPTION
Here is a proposal to hide this "numbers" and only the name (short description) of the tide areas.
This allows to sort the choice list from the north to south of the French coast.
The StandardPorts.xml file has been changed only to sort the ports also in the same north to south order.
JP
