### PR TITLE
Suppress parsing function to handle other languages than English

### DIFF
--- a/src/frcurrentsUIDialog.h
+++ b/src/frcurrentsUIDialog.h
@@ -178,8 +178,8 @@ public:
   wxString CalcCoefficient();
   int CalcHoursFromHWNow();
   int CalcHoursFromLWNow();
-  wxString nearestHW[8];
-  wxString nearestLW[8];
+  wxDateTime nearestHW[8];
+  wxDateTime nearestLW[8];
   bool m_bUseBM;
   int round(double c);
 
@@ -283,11 +283,10 @@ private:
   wxString label_lw[13];
   float tcv[26];
 
-  int myDateSelection;
   wxDateTime m_SelectedDate; //  to store the current selected date
   wxString euTC[8][4];  // Date.Time, Height, Units, HW.LW
   wxDateTime m_dt;
-  wxDateTime choice_dt;
+  vector<wxDateTime> m_choice2_dt;
   wxDateTime back_dt;
   wxDateTime next_dt;
   wxTimeSpan m_ts;


### PR DESCRIPTION
Obviously, the parsing functions do not handle others languages, especially when days and months are stored in their name which is the case here.
I propose a solution : Do not use the parsing function. Instead, store the HW/LW wxDateTime in a std::vector in parallel to the string stored in wxChoice. This suppresses the need for parsing.
I don't know how react parsing function on others platforms, but the code should work everywhere.
