### PR TITLE
Add an option to display times in local device

### DIFF
--- a/src/frcurrentsUIDialog.h
+++ b/src/frcurrentsUIDialog.h
@@ -138,7 +138,8 @@ public:
   ~frcurrentsUIDialog();
 
   void OpenFile(bool newestFile = false);
-
+  wxDateTime GetNow();
+  void SetNow();
   void SetScaledBitmaps(double scalefactor);
 
   void SetViewPort(PlugIn_ViewPort* vp);
@@ -214,7 +215,6 @@ private:
   void CalcHW(int PortCode);
   void CalcLW(int PortCode);
   double CalcRange_Brest();
-  void SetNow();
   void SetCorrectHWSelection();
   void OnDateSelChanged(wxDateEvent& event);
   void OnPortChanged(wxCommandEvent& event);

--- a/src/frcurrentsUIDialogBase.cpp
+++ b/src/frcurrentsUIDialogBase.cpp
@@ -45,7 +45,7 @@ frcurrentsUIDialogBase::frcurrentsUIDialogBase( wxWindow* parent, wxWindowID id,
 	m_choice1 = new wxChoice( sbSizer6->GetStaticBox(), wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choice1Choices, 0 );
 	m_choice1->SetToolTip(_("Select Port"));
 	m_choice1->SetSelection( 0 );
-	sbSizer6->Add( m_choice1, 0, wxALL, 5 );
+	sbSizer6->Add( m_choice1, 0, wxEXPAND|wxALL, 5 );
 
 	bSizerMain->Add( sbSizer6, 0, wxEXPAND, 5 );
 
@@ -146,7 +146,8 @@ frcurrentsUIDialogBase::frcurrentsUIDialogBase( wxWindow* parent, wxWindowID id,
 
 	m_staticText1 = new wxStaticText(this, wxID_FIND, "Time Zone", wxDefaultPosition, wxDefaultSize, 0);
 	m_staticText1->Wrap(-1);
-	bSizer5->Add(m_staticText1, 0, wxALL, 5);
+	m_staticText1->SetToolTip(_("'Local TZ' means Time Zone set on your device"));
+	bSizer5->Add(m_staticText1, 0, wxEXPAND|wxALL, 5);
 
 	wxStaticLine* m_staticline1 = new wxStaticLine( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL );
 	bSizer5->Add(m_staticline1, 0, wxEXPAND | wxALL, 5 );
@@ -360,6 +361,17 @@ frcurrentsPreferencesDialogBase::frcurrentsPreferencesDialogBase( wxWindow* pare
 	wxStaticBoxSizer * sbSizerIconsFactor;
 	sbSizerIconsFactor = new wxStaticBoxSizer(new wxStaticBox(sbSizerScale->GetStaticBox(), wxID_ANY, _("Icons Size Factor")), wxVERTICAL);
 
+	wxStaticBoxSizer* sbSizerTime;
+	sbSizerTime = new wxStaticBoxSizer(new wxStaticBox(sbSizerScale->GetStaticBox(), wxID_ANY, _("Time Zone Options")), wxVERTICAL);
+	wxString m_choiceTimes[] = { _("UTC"), _("Local TZ") };
+	int m_choiceNTimes = sizeof(m_choiceTimes) / sizeof(wxString);
+	m_rTimeZoneOptions = new wxRadioBox(sbSizerTime->GetStaticBox(), wxID_ANY, _(""),
+		wxDefaultPosition, wxDefaultSize, m_choiceNTimes, m_choiceTimes, 0, wxRA_SPECIFY_ROWS);
+	m_rTimeZoneOptions->SetToolTip(_("'Local TZ' means Time Zone set on your device"));
+	sbSizerTime->Add(m_rTimeZoneOptions, 0, wxEXPAND, 5);
+
+	sbSizerScale->Add(sbSizerTime, 0, wxEXPAND, 5);
+
 	m_sIconSizeFactor =
 	new wxSlider(sbSizerIconsFactor->GetStaticBox(), wxID_ANY, 0, -6, 6, wxDefaultPosition,
 					wxDefaultSize, wxSL_BOTTOM | wxSL_HORIZONTAL | wxSL_LABELS);
@@ -399,6 +411,7 @@ frcurrentsPreferencesDialogBase::frcurrentsPreferencesDialogBase( wxWindow* pare
 	m_cStyle->Connect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( frcurrentsPreferencesDialogBase::OnChoice ), NULL, this );
 	m_sIconSizeFactor->Connect(wxEVT_SLIDER, wxCommandEventHandler(frcurrentsPreferencesDialogBase::OnIconsSlidersChange), NULL, this);
 	m_sFontSizeFactor->Connect(wxEVT_SLIDER, wxCommandEventHandler(frcurrentsPreferencesDialogBase::OnFontSlidersChange), NULL, this);
+	m_rTimeZoneOptions->Connect(wxEVT_RADIOBOX, wxCommandEventHandler(frcurrentsPreferencesDialogBase::OnTimeZoneChange), NULL, this);
 }
 
 frcurrentsPreferencesDialogBase::~frcurrentsPreferencesDialogBase()
@@ -407,4 +420,5 @@ frcurrentsPreferencesDialogBase::~frcurrentsPreferencesDialogBase()
 	m_cStyle->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( frcurrentsPreferencesDialogBase::OnChoice ), NULL, this );
 	m_sIconSizeFactor->Disconnect(wxEVT_SLIDER, wxCommandEventHandler(frcurrentsPreferencesDialogBase::OnIconsSlidersChange), NULL, this);
 	m_sFontSizeFactor->Disconnect(wxEVT_SLIDER, wxCommandEventHandler(frcurrentsPreferencesDialogBase::OnFontSlidersChange), NULL, this);
+	m_rTimeZoneOptions->Disconnect(wxEVT_RADIOBOX, wxCommandEventHandler(frcurrentsPreferencesDialogBase::OnTimeZoneChange), NULL, this);
 }

--- a/src/frcurrentsUIDialogBase.h
+++ b/src/frcurrentsUIDialogBase.h
@@ -33,6 +33,7 @@
 #include <wx/clrpicker.h>
 #include <wx/event.h>
 #include <wx/slider.h>
+#include <wx/radiobox.h>
 ///////////////////////////////////////////////////////////////////////////
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -112,7 +113,7 @@ protected:
   virtual void OnChoice(wxCommandEvent& event) { event.Skip(); }
   virtual void OnIconsSlidersChange(wxCommandEvent& event) { event.Skip(); }
   virtual void OnFontSlidersChange(wxCommandEvent & event) { event.Skip(); }
-
+  virtual void OnTimeZoneChange(wxCommandEvent& event) { event.Skip(); }
 public:
   wxCheckBox* m_cbUseRate;
   wxCheckBox* m_cbUseDirection;
@@ -126,6 +127,7 @@ public:
   wxChoice* m_cStyle;
   wxSlider* m_sIconSizeFactor;
   wxSlider * m_sFontSizeFactor;
+  wxRadioBox* m_rTimeZoneOptions;
 
   frcurrentsPreferencesDialogBase(wxWindow* parent, wxWindowID id = wxID_ANY,
                                   const wxString& title = _("Preferences"),

--- a/src/frcurrents_pi.h
+++ b/src/frcurrents_pi.h
@@ -81,6 +81,7 @@ public:
   void SetDialogFont(wxWindow *dialog, wxFont *font);
 #endif
   void OnToolbarToolCallback(int id);
+  int VerifyTimeZoneID(int id);
 
   // Other public methods
   void SetfrcurrentsDialogX(int x) { m_frcurrents_dialog_x = x; };
@@ -96,6 +97,8 @@ public:
   bool GetCopyResolution() { return m_bCopyUseHighRes; }
   bool GetCopyColour() { return m_bCopyUseFillColour; }
   int GetCopyArrowStyle() { return m_CopyArrowStyle; }
+  int GetTZoptionID() { return m_bTimeZoneID; }
+  void SetTZoptionID(int id) { m_bTimeZoneID = id; }
 
   wxString GetFolderSelected() { return m_CopyFolderSelected; }
   frcurrentsOverlayFactory *GetfrcurrentsOverlayFactory() {
@@ -138,7 +141,7 @@ private:
   bool m_bCopyUseFillColour;
   int m_CopyArrowStyle;
 
-  int m_bTimeZone;
+  int m_bTimeZoneID;
 
   int m_bStartOptions;
   wxString m_RequestConfig;
@@ -164,5 +167,6 @@ public:
 private:
   void OnIconsSlidersChange(wxCommandEvent &event);
   void OnFontSlidersChange(wxCommandEvent &event);
+  void OnTimeZoneChange(wxCommandEvent& event);
 };
 #endif


### PR DESCRIPTION
I was puzzled, thinking that sailors used to sail along these coasts have to convert each time plugin's times to their watch's. So I propose to add this option.
Summer offset is managed.
To ovoid a too big gap between HW-LW calculation, coefficients calculation etc., I propose to open this option to a limited number of meridians. Currently, I limited to UTC (UK, Portugal, Ireland ... In this case, the only difference with the current UTC is that summer offset is managed) and UTC+1 (France, Spain, Germany, The Netherlands, Sweden ...
Off course, this could be easily changed. Your decision.

Cordialement
JP
