### PR TITLE
Apply view port rotation to current arrows

### DIFF
--- a/src/frcurrentsOverlayFactory.cpp
+++ b/src/frcurrentsOverlayFactory.cpp
@@ -178,7 +178,8 @@ wxColour frcurrentsOverlayFactory::GetSpeedColour(double my_speed) {
 }
 
 bool frcurrentsOverlayFactory::drawCurrentArrow(int x, int y, double rot_angle,
-                                                double scale, double rate) {
+  double scale, double rate, double vp_rotate_angle)
+{
   double m_rate = fabs(rate);
 
   GetArrowStyle(m_ShowArrowStyle);
@@ -198,8 +199,8 @@ bool frcurrentsOverlayFactory::drawCurrentArrow(int x, int y, double rot_angle,
     m_dc->SetPen(pen);
     m_dc->SetBrush(brush);
   }
-  float sin_rot = sin(rot_angle * PI / 180.);
-  float cos_rot = cos(rot_angle * PI / 180.);
+  float sin_rot = sin((rot_angle * PI / 180.) + vp_rotate_angle);
+  float cos_rot = cos((rot_angle * PI / 180.) + vp_rotate_angle);
 
   // Move to the first point
 
@@ -391,7 +392,7 @@ void frcurrentsOverlayFactory::RenderMyArrows(PlugIn_ViewPort *vp) {
       // dir = 45.00;
       // myCurrent = 0.5;
 
-      bool d = drawCurrentArrow(p.x, p.y, dir - 90, scale / 100, myCurrent);
+      bool d = drawCurrentArrow(p.x, p.y, dir - 90, scale / 100, myCurrent, vp->rotation);
 
       int shift = 0;
 

--- a/src/frcurrentsOverlayFactory.h
+++ b/src/frcurrentsOverlayFactory.h
@@ -126,7 +126,7 @@ private:
   wxColour GetSpeedColour(double my_speed);
 
   bool drawCurrentArrow(int x, int y, double rot_angle, double scale,
-                        double rate);
+    double rate, double vp_rotate_angle);
 
   double m_last_vp_scale;
 


### PR DESCRIPTION
This allows to use the plugin and show currents during navigation when using course up or heading up