### PR TITLE
Move Harmonic Choice to Plugin Preferences

### DIFF
--- a/src/frcurrentsUIDialog.h
+++ b/src/frcurrentsUIDialog.h
@@ -137,6 +137,8 @@ public:
   ~frcurrentsUIDialog();
 
   void OpenFile(bool newestFile = false);
+  void LoadTCMFile();
+  void LoadHarmonics();
   wxDateTime GetNow();
   void SetNow();
   void SetScaledBitmaps(double scalefactor);
@@ -181,7 +183,6 @@ public:
   vector<SHOMport> portLines;
   wxString g_SData_Locn;
   TCMgr* ptcmgr;
-  wxString m_FolderSelected;
   double m_coeff;
   double m_jumpLat, m_jumpLon;
   PlugIn_ViewPort* m_vp;
@@ -223,10 +224,6 @@ private:
   int FindPortIDUsingChoice(wxString inPortName);
   int FindTidePortUsingChoice(wxString inAreaNumber);
 
-  void OnSelectData(wxCommandEvent& event);
-  bool m_harmonics;
-  void LoadTCMFile();
-  void LoadHarmonics();
   int FindPortID(wxString myPort);
   bool LoadStandardPorts();
   void OnAreaSelected(wxCommandEvent& event);

--- a/src/frcurrentsUIDialogBase.cpp
+++ b/src/frcurrentsUIDialogBase.cpp
@@ -154,19 +154,6 @@ frcurrentsUIDialogBase::frcurrentsUIDialogBase( wxWindow* parent, wxWindowID id,
 
 	bSizerMain->Add( bSizer5, 0, wxEXPAND, 5 );
 
-	wxStaticBoxSizer* sbSizer61;
-	sbSizer61 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Tide Harmonics IDX Directory") ), wxVERTICAL );
-
-	m_button7 = new wxButton( sbSizer61->GetStaticBox(), wxID_ANY, _("Select Directory"), wxDefaultPosition, wxDefaultSize, 0 );
-	sbSizer61->Add( m_button7, 0, wxALL, 5 );
-
-	m_dirPicker1 = new wxTextCtrl( sbSizer61->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-	sbSizer61->Add( m_dirPicker1, 0, wxALL|wxEXPAND, 5 );
-
-
-	bSizerMain->Add( sbSizer61, 1, wxEXPAND, 5 );
-
-
 	this->SetSizer( bSizerMain );
 	this->Layout();
 	bSizerMain->Fit( this );
@@ -188,7 +175,6 @@ frcurrentsUIDialogBase::frcurrentsUIDialogBase( wxWindow* parent, wxWindowID id,
 	m_button5->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( frcurrentsUIDialogBase::OnChooseTideButton ), NULL, this );
 	m_button4->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( frcurrentsUIDialogBase::OnChooseTideButton ), NULL, this );
 	m_button6->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( frcurrentsUIDialogBase::OnChooseTideButton ), NULL, this );
-	m_button7->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( frcurrentsUIDialogBase::OnSelectData ), NULL, this );
         this->Connect(
             wxEVT_CONTEXT_MENU,
             wxContextMenuEventHandler(frcurrentsUIDialogBase::OnContextMenu),
@@ -212,7 +198,7 @@ frcurrentsUIDialogBase::~frcurrentsUIDialogBase()
 	this->Disconnect( wxEVT_LEFT_DCLICK, wxMouseEventHandler( frcurrentsUIDialogBase::OnDLeftClick ) );
 	this->Disconnect( wxEVT_MOVE, wxMoveEventHandler( frcurrentsUIDialogBase::OnMove ) );
 	this->Disconnect( wxEVT_SIZE, wxSizeEventHandler( frcurrentsUIDialogBase::OnSize ) );
-        this->Disconnect(
+	this->Disconnect(
             wxEVT_LEFT_DOWN,
             wxMouseEventHandler(frcurrentsUIDialogBase::OnMouseEvent));
         this->Disconnect(wxEVT_LEFT_UP,
@@ -229,8 +215,6 @@ frcurrentsUIDialogBase::~frcurrentsUIDialogBase()
 	m_button5->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( frcurrentsUIDialogBase::OnChooseTideButton ), NULL, this );
 	m_button4->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( frcurrentsUIDialogBase::OnChooseTideButton ), NULL, this );
 	m_button6->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( frcurrentsUIDialogBase::OnChooseTideButton ), NULL, this );
-	m_button7->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( frcurrentsUIDialogBase::OnSelectData ), NULL, this );
-
 
   this->Disconnect(
             wxEVT_CONTEXT_MENU,
@@ -355,6 +339,17 @@ frcurrentsPreferencesDialogBase::frcurrentsPreferencesDialogBase( wxWindow* pare
 
 	bSizerMain->Add( bSizer4, 0, wxEXPAND, 5 );
 
+	wxStaticBoxSizer* sbSizerHarmonics;
+	sbSizerHarmonics = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, _("Tide Harmonics IDX Directory")), wxVERTICAL);
+
+	m_button7 = new wxButton(sbSizerHarmonics->GetStaticBox(), wxID_ANY, _("Select Directory"), wxDefaultPosition, wxDefaultSize, 0);
+	sbSizerHarmonics->Add(m_button7, 0, wxALL, 5);
+
+	m_dirPicker1 = new wxTextCtrl(sbSizerHarmonics->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0);
+	sbSizerHarmonics->Add(m_dirPicker1, 0, wxALL | wxEXPAND, 5);
+
+	bSizerMain->Add(sbSizerHarmonics, 1, wxEXPAND, 5);
+
 	wxStaticBoxSizer* sbSizerScale;
 	sbSizerScale = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, wxEmptyString), wxHORIZONTAL);
 
@@ -412,6 +407,7 @@ frcurrentsPreferencesDialogBase::frcurrentsPreferencesDialogBase( wxWindow* pare
 	m_sIconSizeFactor->Connect(wxEVT_SLIDER, wxCommandEventHandler(frcurrentsPreferencesDialogBase::OnIconsSlidersChange), NULL, this);
 	m_sFontSizeFactor->Connect(wxEVT_SLIDER, wxCommandEventHandler(frcurrentsPreferencesDialogBase::OnFontSlidersChange), NULL, this);
 	m_rTimeZoneOptions->Connect(wxEVT_RADIOBOX, wxCommandEventHandler(frcurrentsPreferencesDialogBase::OnTimeZoneChange), NULL, this);
+	m_button7->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(frcurrentsPreferencesDialogBase::OnSelectData), NULL, this);
 }
 
 frcurrentsPreferencesDialogBase::~frcurrentsPreferencesDialogBase()
@@ -421,4 +417,5 @@ frcurrentsPreferencesDialogBase::~frcurrentsPreferencesDialogBase()
 	m_sIconSizeFactor->Disconnect(wxEVT_SLIDER, wxCommandEventHandler(frcurrentsPreferencesDialogBase::OnIconsSlidersChange), NULL, this);
 	m_sFontSizeFactor->Disconnect(wxEVT_SLIDER, wxCommandEventHandler(frcurrentsPreferencesDialogBase::OnFontSlidersChange), NULL, this);
 	m_rTimeZoneOptions->Disconnect(wxEVT_RADIOBOX, wxCommandEventHandler(frcurrentsPreferencesDialogBase::OnTimeZoneChange), NULL, this);
+	m_button7->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(frcurrentsPreferencesDialogBase::OnSelectData), NULL, this);
 }

--- a/src/frcurrentsUIDialogBase.h
+++ b/src/frcurrentsUIDialogBase.h
@@ -67,7 +67,6 @@ protected:
   virtual void OnPrev(wxCommandEvent& event) { event.Skip(); }
   virtual void OnNext(wxCommandEvent& event) { event.Skip(); }
   virtual void OnChooseTideButton(wxCommandEvent& event) { event.Skip(); }
-  virtual void OnSelectData(wxCommandEvent& event) { event.Skip(); }
   virtual void OnContextMenu(wxContextMenuEvent& event) { event.Skip(); }
   virtual void OnContextMenuSelect(wxCommandEvent& event) { event.Skip(); }
   virtual void OnMouseEvent(wxMouseEvent& event) { event.Skip(); }
@@ -108,12 +107,14 @@ protected:
   wxStdDialogButtonSizer* m_sdbSizerButtons;
   wxButton* m_sdbSizerButtonsOK;
   wxButton* m_sdbSizerButtonsCancel;
+  wxButton* m_button7;
 
   // Virtual event handlers, override them in your derived class
   virtual void OnChoice(wxCommandEvent& event) { event.Skip(); }
   virtual void OnIconsSlidersChange(wxCommandEvent& event) { event.Skip(); }
   virtual void OnFontSlidersChange(wxCommandEvent & event) { event.Skip(); }
   virtual void OnTimeZoneChange(wxCommandEvent& event) { event.Skip(); }
+  virtual void OnSelectData(wxCommandEvent& event) { event.Skip(); }
 public:
   wxCheckBox* m_cbUseRate;
   wxCheckBox* m_cbUseDirection;
@@ -124,6 +125,7 @@ public:
   wxColourPickerCtrl* myColourPicker2;
   wxColourPickerCtrl* myColourPicker3;
   wxColourPickerCtrl* myColourPicker4;
+  wxTextCtrl* m_dirPicker1;
   wxChoice* m_cStyle;
   wxSlider* m_sIconSizeFactor;
   wxSlider * m_sFontSizeFactor;

--- a/src/frcurrents_pi.h
+++ b/src/frcurrents_pi.h
@@ -90,7 +90,7 @@ public:
   void SetfrcurrentsDialogSizeY(int x) { m_frcurrents_dialog_sy = x; }
   void SetColorScheme(PI_ColorScheme cs);
 
-  void OnfrcurrentsDialogClose();
+  void OnfrcurrentsDialogClose(bool cancel);
 
   bool GetCopyRate() { return m_bCopyUseRate; }
   bool GetCopyDirection() { return m_bCopyUseDirection; }
@@ -162,11 +162,14 @@ class frcurrentsPreferencesDialog : public frcurrentsPreferencesDialogBase {
 public:
   frcurrentsPreferencesDialog(wxWindow *pparent)
       : frcurrentsPreferencesDialogBase(pparent) {}
+
+
   ~frcurrentsPreferencesDialog() {}
 
 private:
   void OnIconsSlidersChange(wxCommandEvent &event);
   void OnFontSlidersChange(wxCommandEvent &event);
   void OnTimeZoneChange(wxCommandEvent& event);
+  void OnSelectData(wxCommandEvent& event);
 };
 #endif


### PR DESCRIPTION
When starting the plugin, if the user has not yet selected the harmonic directory, he is proposed to select it as before.
Otherwise, the directory can be selected anytime in the Preferences' dialog.
JP