### PR TITLE
Extend JumpTo logic to Port changed and start plugin

### DIFF
--- a/data/StandardPorts.xml
+++ b/data/StandardPorts.xml
@@ -4,6 +4,8 @@
     <PORT_NAME>DUNKERQUE, France</PORT_NAME>
     <LAT>51.039995</LAT>
     <LON>2.346700</LON>
+	<A_LAT>51.1</A_LAT>
+	<A_LON>2.2</A_LON>
     <PMVE>6.05</PMVE>
     <PMME>5.0</PMME>
     <BMME>1.5</BMME>
@@ -15,6 +17,8 @@
     <PORT_NAME>CALAIS, France</PORT_NAME>
     <LAT>50.969333</LAT>
     <LON>1.8675</LON>
+	<A_LAT>50.95</A_LAT>
+	<A_LON>1.75</A_LON>
     <PMVE>7.3</PMVE>
     <PMME>6.05</PMME>
     <BMME>2.05</BMME>
@@ -26,6 +30,8 @@
     <PORT_NAME>BOULOGNE-SUR-MER, France</PORT_NAME>
     <LAT>50.72745</LAT>
     <LON>1.5777</LON>
+	<A_LAT>50.727</A_LAT>
+	<A_LON>1.578</A_LON>
     <PMVE>9.0</PMVE>
     <PMME>7.3</PMME>
     <BMME>2.7</BMME>
@@ -37,6 +43,8 @@
     <PORT_NAME>CONCARNEAU, France</PORT_NAME>
     <LAT>47.875500</LAT>
     <LON>-3.92070</LON>
+	<A_LAT>47.4</A_LAT>
+	<A_LON>-4.135</A_LON>
     <PMVE>5.1</PMVE>
     <PMME>4.0</PMME>
     <BMME>2.0</BMME>
@@ -48,6 +56,8 @@
     <PORT_NAME>ILE de GROIX (Port Tudy), France</PORT_NAME>
     <LAT>47.644583</LAT>
     <LON>-3.4</LON>
+	<A_LAT>47.645</A_LAT>
+	<A_LON>-3.4</A_LON>
     <PMVE>5.2</PMVE>
     <PMME>4.15</PMME>
     <BMME>2.10</BMME>
@@ -59,6 +69,8 @@
     <PORT_NAME>PORT-NAVALO, France</PORT_NAME>
     <LAT>47.55300</LAT>
     <LON>-2.90520</LON>
+	<A_LAT>47.467</A_LAT>
+	<A_LON>-2.9</A_LON>
     <PMVE>05.05</PMVE>
     <PMME>4.0</PMME>
     <BMME>1.9</BMME>
@@ -70,6 +82,8 @@
     <PORT_NAME>SAINT-NAZAIRE, France</PORT_NAME>
     <LAT>47.277400</LAT>
     <LON>-2.21700</LON>
+	<A_LAT>47.091</A_LAT>
+	<A_LON>-2.56</A_LON>
     <PMVE>5.90</PMVE>
     <PMME>4.70</PMME>
     <BMME>2.25</BMME>
@@ -81,6 +95,8 @@
     <PORT_NAME>LES SABLES-D'OLONNE, France</PORT_NAME>
     <LAT>46.50</LAT>
     <LON>-1.80</LON>
+	<A_LAT>46.130</A_LAT>
+	<A_LON>-2.373</A_LON>
     <PMVE>05.35</PMVE>
     <PMME>4.30</PMME>
     <BMME>2.15</BMME>
@@ -92,6 +108,8 @@
     <PORT_NAME>LA ROCHELLE - LA PALLICE, France</PORT_NAME>
     <LAT>46.166695</LAT>
     <LON>-1.21670</LON>
+	<A_LAT>46.096</A_LAT>
+	<A_LON>-1.454</A_LON>
     <PMVE>6.10</PMVE>
     <PMME>4.95</PMME>
     <BMME>2.50</BMME>
@@ -103,6 +121,8 @@
     <PORT_NAME>POINTE DE GRAVE, France</PORT_NAME>
     <LAT>45.566700</LAT>
     <LON>-1.06670</LON>
+	<A_LAT>45.591</A_LAT>
+	<A_LON>-1.356</A_LON>
     <PMVE>5.30</PMVE>
     <PMME>4.35</PMME>
     <BMME>2.10</BMME>
@@ -114,6 +134,8 @@
     <PORT_NAME>BREST, France</PORT_NAME>
     <LAT>48.383297</LAT>
     <LON>-4.50</LON>
+	<A_LAT>48.2</A_LAT>
+	<A_LON>-4.835</A_LON>
     <PMVE>7.05</PMVE>
     <PMME>5.50</PMME>
     <BMME>2.70</BMME>
@@ -125,6 +147,8 @@
     <PORT_NAME>LE HAVRE, France</PORT_NAME>
     <LAT>49.4833</LAT>
     <LON>0.1167</LON>
+	<A_LAT>49.572</A_LAT>
+	<A_LON>0.0</A_LON>
     <PMVE>8.00</PMVE>
     <PMME>6.70</PMME>
     <BMME>2.95</BMME>
@@ -136,6 +160,8 @@
     <PORT_NAME>CHERBOURG, France</PORT_NAME>
     <LAT>49.649998</LAT>
     <LON>-1.63330</LON>
+	<A_LAT>49.721</A_LAT>
+	<A_LON>-1.412</A_LON>
     <PMVE>6.45</PMVE>
     <PMME>5.10</PMME>
     <BMME>2.60</BMME>
@@ -147,6 +173,8 @@
     <PORT_NAME>SAINT-MALO, France</PORT_NAME>
     <LAT>48.633297</LAT>
     <LON>-2.01670</LON>
+	<A_LAT>49.459</A_LAT>
+	<A_LON>-2.4</A_LON>
     <PMVE>12.2</PMVE>
     <PMME>9.3</PMME>
     <BMME>4.3</BMME>
@@ -158,6 +186,8 @@
     <PORT_NAME>PAIMPOL, France</PORT_NAME>
     <LAT>48.790333</LAT>
     <LON>-2.955333</LON>
+	<A_LAT>48.95</A_LAT>
+	<A_LON>-2.95</A_LON>
     <PMVE>10.95</PMVE>
     <PMME>8.45</PMME>
     <BMME>4.0</BMME>
@@ -169,6 +199,8 @@
     <PORT_NAME>ROSCOFF, France</PORT_NAME>
     <LAT>48.716698</LAT>
     <LON>-3.97670</LON>
+	<A_LAT>48.9</A_LAT>
+	<A_LON>-3.7</A_LON>
     <PMVE>8.90</PMVE>
     <PMME>7.10</PMME>
     <BMME>3.40</BMME>
@@ -180,6 +212,8 @@
     <PORT_NAME>CHERBOURG, France</PORT_NAME>
     <LAT>49.649998</LAT>
     <LON>-1.63330</LON>
+	<A_LAT>50.0</A_LAT>
+	<A_LON>-2.5</A_LON>
     <PMVE>6.45</PMVE>
     <PMME>5.10</PMME>
     <BMME>2.60</BMME>
@@ -191,6 +225,8 @@
     <PORT_NAME>CONCARNEAU, France</PORT_NAME>
     <LAT>47.2</LAT>
     <LON>-5.0</LON>
+	<A_LAT>46.2</A_LAT>
+	<A_LON>-4.43</A_LON>
     <PMVE>5.10</PMVE>
     <PMME>4.00</PMME>
     <BMME>2.00</BMME>

--- a/src/frcurrentsUIDialog.cpp
+++ b/src/frcurrentsUIDialog.cpp
@@ -472,8 +472,9 @@ void frcurrentsUIDialog::OnStartSetupHW() {
   SetNow();
 }
 
-void frcurrentsUIDialog::SetNow() {
-  if (!SetDateForNowButton()) return;
+void frcurrentsUIDialog::SetNow(bool m_acenter) {
+
+  if (!SetDateForNowButton(m_acenter)) return;
 
   // calc coefficient
   BrestRange = CalcRange_Brest();
@@ -662,7 +663,7 @@ void frcurrentsUIDialog::OnDateSelChanged(wxDateEvent& event) {
 
 void frcurrentsUIDialog::OnPortChanged(wxCommandEvent& event) { SetNow(); }
 
-bool frcurrentsUIDialog::SetDateForNowButton() {
+bool frcurrentsUIDialog::SetDateForNowButton(bool m_bcenter) {
   m_IsNotShowable = false;
   m_staticText2->SetLabel("");
   m_staticText211->SetLabel("");
@@ -696,6 +697,13 @@ bool frcurrentsUIDialog::SetDateForNowButton() {
     RequestRefresh(pParent);
     return false;
   } else {
+
+    if (m_bcenter) {
+      double inLAT, inLON;
+      FindPortAreaCenter(sa, string, inLAT, inLON);
+      JumpToPosition(inLAT, inLON, pPlugIn->my_chart_scale);
+    }
+
     GetCurrentsData(sa);
 
     CalcHW(id);
@@ -879,6 +887,27 @@ int frcurrentsUIDialog::FindTidePortUsingChoice(wxString inAreaNumber) {
   }
   m_choice1->Fit();
   return 0;
+}
+
+void frcurrentsUIDialog::FindPortAreaCenter(wxString area, wxString port, double &outLAT,
+  double &outLON) {
+  PortTides myPortTides;
+  for (std::vector<StandardPort>::iterator it = my_ports.begin();
+    it != my_ports.end(); it++) {
+    myPortTides.m_portID = (*it).PORT_NUMBER;
+    myPortTides.m_portName = (*it).PORT_NAME;
+
+    if (myPortTides.m_portID == area && myPortTides.m_portName == port) {
+      double value;
+      wxString svalue;
+      svalue = (*it).A_LAT;
+      svalue.ToDouble(&value);
+      outLAT = value;
+      svalue = (*it).A_LON;
+      svalue.ToDouble(&value);
+      outLON = value;
+    }
+  }
 }
 
 int frcurrentsUIDialog::FindPortIDUsingChoice(wxString inPortName) {
@@ -1394,7 +1423,7 @@ bool frcurrentsUIDialog::LoadStandardPorts() {
 
   int count = 0;
 
-  wxString wxPORT_NUMBER, wxPORT_NAME, wxPORT_LAT, wxPORT_LON, PMVE, PMME, BMVE,
+  wxString wxPORT_NUMBER, wxPORT_NAME, wxPORT_LAT, wxPORT_LON, wxA_LAT, wxA_LON, PMVE, PMME, BMVE,
       BMME, IDX;
 
   int i = 0;
@@ -1420,6 +1449,16 @@ bool frcurrentsUIDialog::LoadStandardPorts() {
       if (!strcmp(f->Value(), "LON")) {
         wxPORT_LON = wxString::FromUTF8(f->GetText());
         my_port.LON = wxPORT_LON;
+      }
+
+      if (!strcmp(f->Value(), "A_LAT")) {
+        wxA_LAT = wxString::FromUTF8(f->GetText());
+        my_port.A_LAT = wxA_LAT;
+      }
+
+      if (!strcmp(f->Value(), "A_LON")) {
+        wxA_LON = wxString::FromUTF8(f->GetText());
+        my_port.A_LON = wxA_LON;
       }
 
       if (!strcmp(f->Value(), "PMVE")) {
@@ -1458,59 +1497,6 @@ bool frcurrentsUIDialog::LoadStandardPorts() {
 
 void frcurrentsUIDialog::OnAreaSelected(wxCommandEvent& event) {
   int a = m_choiceArea->GetSelection();
-
-  int m_area_chosen = a;
-  double myLat, myLon;
-  myLat = 50.0, myLon = -2.0;
-
-  switch (m_area_chosen) {
-    case 0:
-      myLat = 51.1;
-      myLon = 2.2;
-      JumpToPosition(myLat, myLon, my_chart_scale);
-      break;
-    case 1:
-      myLat = 50.0;
-      myLon = -0.9;
-      JumpToPosition(myLat, myLon, my_chart_scale);
-      break;
-    case 2:
-      myLat = 49.5403;
-      myLon = -0.0766;
-      JumpToPosition(myLat, myLon, my_chart_scale);
-      break;
-    case 3:
-      myLat = 49.3;
-      myLon = -2.4;
-      JumpToPosition(myLat, myLon, my_chart_scale);
-      break;
-    case 4:
-      myLat = 48.9;
-      myLon = -3.7;
-      JumpToPosition(myLat, myLon, my_chart_scale);
-      break;
-    case 5:
-      myLat = 48.362570;
-      myLon = -4.500263;
-      JumpToPosition(myLat, myLon, my_chart_scale);
-      break;
-    case 6:
-      myLat = 47.5;
-      myLon = -4.1;
-      JumpToPosition(myLat, myLon, my_chart_scale);
-      break;
-    case 7:
-      myLat = 47.0;
-      myLon = -2.5;
-      JumpToPosition(myLat, myLon, my_chart_scale);
-      break;
-    case 8:
-      myLat = 46.0;
-      myLon = -3.7;
-      JumpToPosition(myLat, myLon, my_chart_scale);
-      break;
-  }
-
   wxString s = m_Areas[a];
 
   FindTidePortUsingChoice(s);  // populate m_choice1 (this area's ports list)

--- a/src/frcurrentsUIDialog.h
+++ b/src/frcurrentsUIDialog.h
@@ -127,7 +127,7 @@ public:
 
 class StandardPort {
 public:
-  wxString PORT_NUMBER, PORT_NAME, LAT, LON, IDX, PMVE, PMME, BMVE, BMME;
+  wxString PORT_NUMBER, PORT_NAME, LAT, LON, A_LAT, A_LON, IDX, PMVE, PMME, BMVE, BMME;
   double spRange, npRange;
 };
 
@@ -140,7 +140,7 @@ public:
   void LoadTCMFile();
   void LoadHarmonics();
   wxDateTime GetNow();
-  void SetNow();
+  void SetNow(bool m_acenter = true);
   void SetScaledBitmaps(double scalefactor);
 
   void SetViewPort(PlugIn_ViewPort* vp);
@@ -186,7 +186,6 @@ public:
   double m_coeff;
   double m_jumpLat, m_jumpLon;
   PlugIn_ViewPort* m_vp;
-  float my_chart_scale;
   bool m_IsNotShowable;
 
   
@@ -210,20 +209,21 @@ private:
   void OnClose(wxCloseEvent& event);
   void OnMove(wxMoveEvent& event);
   void OnStartSetupHW();
-  void OnNow(wxCommandEvent& event) { SetNow(); }
+  void OnNow(wxCommandEvent& event) { SetNow(false); }
 
   void CalcHW(int PortCode);
   double CalcRange_Brest();
   void SetCorrectHWSelection();
   void OnDateSelChanged(wxDateEvent& event);
   void OnPortChanged(wxCommandEvent& event);
-  bool SetDateForNowButton();
+  bool SetDateForNowButton(bool m_bcenter);
 
   void OnPreferences(wxCommandEvent& event);
   wxString FindPortXMLUsingChoice(wxString inPortName);
 
   int FindPortIDUsingChoice(wxString inPortName);
   int FindTidePortUsingChoice(wxString inAreaNumber);
+  void FindPortAreaCenter(wxString area, wxString port, double &jump_LAT, double &Jump_LON);
 
   int FindPortID(wxString myPort);
   bool LoadStandardPorts();

--- a/src/frcurrents_pi.cpp
+++ b/src/frcurrents_pi.cpp
@@ -418,11 +418,11 @@ void frcurrents_pi::OnfrcurrentsDialogClose() {
 }
 
 bool frcurrents_pi::RenderOverlay(wxDC &dc, PlugIn_ViewPort *vp) {
+  my_chart_scale = vp->view_scale_ppm;
   if (!m_pfrcurrentsDialog || !m_pfrcurrentsDialog->IsShown() ||
       !m_pfrcurrentsOverlayFactory)
     return false;
   m_pfrcurrentsDialog->SetViewPort(vp);
-  m_pfrcurrentsDialog->my_chart_scale = vp->view_scale_ppm;
   piDC pidc(dc);
   m_pfrcurrentsOverlayFactory->RenderOverlay(pidc, *vp);
   return true;
@@ -430,12 +430,12 @@ bool frcurrents_pi::RenderOverlay(wxDC &dc, PlugIn_ViewPort *vp) {
 
 bool frcurrents_pi::RenderGLOverlay(wxGLContext *pcontext,
                                     PlugIn_ViewPort *vp) {
+  my_chart_scale = vp->view_scale_ppm;
   if (!m_pfrcurrentsDialog || !m_pfrcurrentsDialog->IsShown() ||
       !m_pfrcurrentsOverlayFactory)
     return false;
 
   m_pfrcurrentsDialog->SetViewPort(vp);
-  m_pfrcurrentsDialog->my_chart_scale = vp->view_scale_ppm;    
   piDC piDC;
   glEnable(GL_BLEND);
   piDC.SetVP(vp);
@@ -560,7 +560,7 @@ void frcurrentsPreferencesDialog::OnTimeZoneChange(wxCommandEvent& event) {
     if (id != idx) {
       m_rTimeZoneOptions->SetSelection(idx);
       if (g_pi->m_pfrcurrentsDialog)
-        g_pi->m_pfrcurrentsDialog->SetNow(); // force returning to now to activate new TZ chosen
+        g_pi->m_pfrcurrentsDialog->SetNow(false); // force returning to now to activate new TZ chosen
     }
   }
 }

--- a/src/frcurrents_pi.h
+++ b/src/frcurrents_pi.h
@@ -115,6 +115,7 @@ public:
   frcurrentsUIDialog *m_pfrcurrentsDialog;
   double my_IconsScaleFactor;
   int my_FontpointSizeFactor;
+  float my_chart_scale;
 
 private:
   int m_position_menu_id;


### PR DESCRIPTION
This commit is just a proposal. 
The "jump To" function was a very good thing.
I propose here to extend it to ports change and to the start of the plugin
In fact, the current "Jump To" centers around the first Area's port tide. For the first area, (Strait of Dover) for example, the center is around Dunkerque. If then you choose Calais, you see nothing because the Calais' sub area is outside the screen.
The same for South Brittany, Vendée-Gironde etc.
To avoid many "if" or "case", the positions to jump to are included in the StandardPorts.xml
file.
 JP
